### PR TITLE
Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.DS_Store
+/target
+data.tgz
+amardiscord.sqlite

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM rust:alpine AS build
+
+RUN apk add --no-cache build-base sqlite-dev
+WORKDIR /build
+COPY . .
+RUN cargo build --release --locked
+RUN /build/target/release/amardiscord build
+
+FROM alpine:latest
+
+WORKDIR /app
+COPY --from=build /build/target/release/amardiscord /app/amardiscord
+COPY --from=build /build/amardiscord.sqlite /app/amardiscord.sqlite
+
+ENTRYPOINT ["/app/amardiscord", "serve"]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -53,7 +53,7 @@ pub async fn serve() -> Result<()> {
     info!("Loading content...");
     let state = Arc::new(Database::new().unwrap());
 
-    info!("Starting app on http://localhost:3000");
+    info!("Starting app on http://0.0.0.0:3000");
 
     let app = Router::new()
         .route("/", get(|| async { Html(IndexTemplate::render()) }))


### PR DESCRIPTION
This PR adds a `Dockerfile` for building `amardiscord`'s image.

I also added a quick fix to the build time dump JSON file discovery algorithm to an issue I discovered while curating the categories data. Before this change, we had to have sequential `1.json`, `2.json`, ... `n.json` files, and any gap inbetween those would halt the discovery; now we can delete them arbitrarily and get the same intended result.

I also added a quick documentation note to `README.md`, but I'd also would like to link to the tool that was used for dumping the server's data in the first place. @StenniHub, do you know what that was? I can't remember. 