### PR TITLE
Mount data directory and build DB inside Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ RUN cargo build --release --locked
 
 FROM alpine:latest
 
+RUN apk add --no-cache bash
 WORKDIR /app
-COPY --from=build /build/target/release/amardiscord /app/amardiscord
+COPY serve.sh .
+COPY --from=build /build/target/release/amardiscord /app/target/release/amardiscord
 
-ENTRYPOINT ["/app/amardiscord", "serve"]
+ENTRYPOINT ["/bin/bash", "serve.sh"]

--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ A web UI for browsing Discord backups.
 The backup should have this tree structure:
 
 ```
-$ ls --tree my-server-backup
- my-server-backup
-├──  1168694611581865984.json
-└──  1168694611581865984
+$ ls --tree data
+ data
+└──  my_discord_backup
     ├──  categories
     │   ├──  1.json
     │   ├──  10.json
@@ -29,7 +28,7 @@ $ ls --tree my-server-backup
         └──  1.json
 ```
 
-Note that the top-level `.json` file is ignored, and `other_channels` is optional.
+Note that any top-level `.json` files are ignored, and `other_channels` is optional.
 
 ### Free-standing compilation
 
@@ -39,11 +38,13 @@ You can install `amardiscord` via Cargo:
 # Compile the code
 cargo install --locked --git https://github.com/soulsspeedruns/amardiscord
 
-# Build the SQLite database from the backup
-amardiscord build /path/to/my-server-backup
+# Build the SQLite database from the backup (no argument defaults to ./data)
+amardiscord build /path/to/backup
 
 # Serve the content
 amardiscord serve
+
+Alternatively, serve.sh performs the build and serve steps for you by first checking whether the SQLite daatabase already exists.
 ```
 
 ### Docker image
@@ -57,13 +58,12 @@ Then, build and start the container, mounting the database file at `/app/amardis
 # Clone the repo
 git clone https://github.com/soulsspeedruns/amardiscord && cd amardiscord
 
-# Build the database file
-cargo run --release -- build /path/to/my-server-backup
-
-# Build and run the Docker image
+# Build the Docker image
 docker build -t amardiscord .
+
+# Run the Docker container and mount the data directory containing your Discord backup (example above)
 docker run --rm -it \
     -p 3000:3000 \
-    -v ./amardiscord.sqlite:/app/amardiscord.sqlite:ro \
+    -v ./data:/app/data \
     amardiscord
 ```

--- a/serve.sh
+++ b/serve.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# TODO: Add argument for whether to run in production or debug mode
+if [ -e "./data/amardiscord.sqlite" ]; then
+    echo "SQLite database already exists, skipping build step."
+else
+    ./target/release/amardiscord build
+fi
+
+./target/release/amardiscord serve

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -138,7 +138,7 @@ impl Database {
         Ok(Self(
             Pool::builder()
                 .max_size(32)
-                .build(SqliteConnectionManager::file("amardiscord.sqlite"))?,
+                .build(SqliteConnectionManager::file("./data/amardiscord.sqlite"))?,
         ))
     }
 
@@ -258,7 +258,7 @@ impl Database {
 }
 
 pub async fn build(path: Option<PathBuf>) -> Result<(), Error> {
-    let sqlite_path = Path::new("amardiscord.sqlite");
+    let sqlite_path = Path::new("./data/amardiscord.sqlite");
 
     if sqlite_path.exists() {
         fs::remove_file(sqlite_path).await?;


### PR DESCRIPTION
Now mounts data directory with backup directly and builds the SQLite file if it doesn't already exist.
Also moved the default SQLite directory to ./data, not verified what happens if the folder does not exist.
Still stuff we can improve, but I think this gives us a decent reusable Docker image.