### PR TITLE
Fix FTS query error

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -205,6 +205,10 @@ impl Database {
     }
 
     pub fn get_search(&self, search_query: SearchQuery) -> Result<Vec<SearchResult>, Error> {
+        if search_query.is_empty() {
+            return Ok(Vec::new());
+        }
+
         let db = self.0.get()?;
 
         let (query, params) = search_query.build()?;

--- a/src/search.rs
+++ b/src/search.rs
@@ -77,6 +77,10 @@ impl SearchQuery {
 
         Ok((query, params))
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.content.is_empty() && self.username.as_ref().is_none_or(String::is_empty)
+    }
 }
 
 // Risks of injection are prevented by whitelisting only alphanumeric characters

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,14 +1,18 @@
 <ul class="messages">
-{% for SearchResultGroup { username, first_search_result, search_results } in search_result_groups %}
-  <li class="username">
-    <span class="avatar"><img alt="" src="{{ first_search_result.message.avatar }}"/></span>
-    <span class="usr">{{ username }}</span>
-    <span class="time">{{ first_search_result.message.sent_at }}</span>
-    <a href="/message/{{ first_search_result.message_rowid }}" class="jump-btn">Jump</a>
-  </li>
-  <li class="msg">{{ first_search_result.message.content|escape("none") }}</li>
-  {% for search_result in search_results %}
-  <li class="msg">{{ search_result.message.content|escape("none") }}</li>
+{% if search_result_groups.is_empty() %}
+  No results found
+{% else %}
+  {% for SearchResultGroup { username, first_search_result, search_results } in search_result_groups %}
+    <li class="username">
+      <span class="avatar"><img alt="" src="{{ first_search_result.message.avatar }}"/></span>
+      <span class="usr">{{ username }}</span>
+      <span class="time">{{ first_search_result.message.sent_at }}</span>
+      <a href="/message/{{ first_search_result.message_rowid }}" class="jump-btn">Jump</a>
+    </li>
+    <li class="msg">{{ first_search_result.message.content|escape("none") }}</li>
+    {% for search_result in search_results %}
+    <li class="msg">{{ search_result.message.content|escape("none") }}</li>
+    {% endfor %}
   {% endfor %}
-{% endfor %}
+{% endif %}
 </ul>


### PR DESCRIPTION
This PR fixes the error received when the query field is cleared by just returning an empty vector when the query is empty.

Closes #19, stacks on top of #23.